### PR TITLE
Tweak projects page

### DIFF
--- a/assets/app/views/createProject.html
+++ b/assets/app/views/createProject.html
@@ -16,7 +16,7 @@
                 pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?"
                 aria-describedby="nameHelp"
                 ng-model="name"
-                ng-model-options="{ updateOn: 'default blur', debounce: {'default': 750, 'blur': 0} }"
+                ng-model-options="{ updateOn: 'default blur'}"
                 ng-change="nameTaken = false"></input>
           </span>
           <div>

--- a/assets/app/views/projects.html
+++ b/assets/app/views/projects.html
@@ -17,11 +17,9 @@
     <div class="muted" style="margin-top: -5px;" ng-if="project | annotation : 'description'">{{project | annotation : 'description'}}</div>
   </div>
   <div ng-if="emptyMessage && (projects | hashSize) == 0">{{emptyMessage}}</div>
-  <div ng-if="!canCreate" style="margin-top: 10px;">
-    <span ng-if="!newProjectMessage">
-      To create a new project, run <code>osadm new-project &lt;projectname&gt;</code>
-    </span>
-    {{newProjectMessage}}
+  <div ng-if="canCreate === false" style="margin-top: 10px;">
+    <span ng-if="!newProjectMessage">To create a new project, run <code>osadm new-project &lt;projectname&gt;</code></span>
+    <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" style="white-space:pre;"></span>
   </div>
   <div style="margin-top: 10px;">
     To be added as an admin to an existing project, run <code>osadm policy add-role-to-user admin {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -143,6 +143,14 @@ func (r *REST) List(ctx kapi.Context, label labels.Selector, field fields.Select
 	forbiddenError, _ := kapierror.NewForbidden("ProjectRequest", "", errors.New("You may not request a new project via this API.")).(*kapierror.StatusError)
 	if len(r.message) > 0 {
 		forbiddenError.ErrStatus.Message = r.message
+		forbiddenError.ErrStatus.Details = &kapi.StatusDetails{
+			Kind: "ProjectRequest",
+			Causes: []kapi.StatusCause{
+				{Message: r.message},
+			},
+		}
+	} else {
+		forbiddenError.ErrStatus.Message = "You may not request a new project via this API."
 	}
 	return nil, forbiddenError
 }


### PR DESCRIPTION
- [x] Start with `canCreate` undefined, so we don't flash the "To create a new project..." text while we're checking.
- [x] Add the custom message to the details field on the server side so we don't have to run regexes :)
- [x] Preserve white-space and linkify the text so admins can present a nice message with a URL that is clickable
- [x] Remove debouncing timeout so form becomes valid immediately once you enter a project name.
